### PR TITLE
Fix PL-2: Allow blank date fields in add/edit book forms

### DIFF
--- a/src/app/api/books/[id]/route.ts
+++ b/src/app/api/books/[id]/route.ts
@@ -83,8 +83,20 @@ export async function PUT(
       );
     }
 
+    // Sanitize the update data - convert empty strings to undefined for optional fields
+    const sanitizedData: Partial<BookFormData> = {};
+    if (body.title !== undefined) sanitizedData.title = body.title;
+    if (body.author !== undefined) sanitizedData.author = body.author?.trim() || undefined;
+    if (body.publish_date !== undefined) sanitizedData.publish_date = body.publish_date?.trim() || undefined;
+    if (body.summary !== undefined) sanitizedData.summary = body.summary?.trim() || undefined;
+    if (body.state !== undefined) sanitizedData.state = body.state;
+    if (body.current_possessor !== undefined) sanitizedData.current_possessor = body.current_possessor;
+    if (body.times_read !== undefined) sanitizedData.times_read = body.times_read;
+    if (body.last_read !== undefined) sanitizedData.last_read = body.last_read?.trim() || undefined;
+    if (body.isbn !== undefined) sanitizedData.isbn = body.isbn?.trim() || undefined;
+
     // Update the book
-    const updatedBook = await updateBook(id, body);
+    const updatedBook = await updateBook(id, sanitizedData);
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/books/route.ts
+++ b/src/app/api/books/route.ts
@@ -51,17 +51,18 @@ export async function POST(request: NextRequest) {
     }
 
     // Create the book with default values for missing fields
+    // Convert empty strings to undefined for optional fields, especially dates
     const bookData = {
       title: body.title,
-      author: body.author || undefined,
-      publish_date: body.publish_date || undefined,
-      summary: body.summary || undefined,
+      author: body.author?.trim() || undefined,
+      publish_date: body.publish_date?.trim() || undefined,
+      summary: body.summary?.trim() || undefined,
       state: body.state,
       current_possessor: body.current_possessor,
       times_read: body.times_read || 0,
-      last_read: body.last_read || undefined,
+      last_read: body.last_read?.trim() || undefined,
       date_added: new Date().toISOString().split('T')[0], // Today's date in YYYY-MM-DD format
-      isbn: body.isbn || undefined
+      isbn: body.isbn?.trim() || undefined
     };
 
     const newBook = await createBook(bookData);


### PR DESCRIPTION
The form was returning errors when date fields (publish_date, last_read) were left blank. This was caused by empty strings being sent to the database, which Postgres couldn't convert to DATE type.

Changes:
- Added sanitization in POST /api/books to trim and convert empty strings to undefined
- Added sanitization in PUT /api/books/[id] to handle empty date strings properly
- Both routes now properly handle blank optional fields including dates

Users can now leave publish_date and last_read fields blank without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)